### PR TITLE
Debug: Clear method was not working  for non-capped collections

### DIFF
--- a/django_mongodb_cash_backend/__init__.py
+++ b/django_mongodb_cash_backend/__init__.py
@@ -223,7 +223,8 @@ class MongoDBCache(BaseCache):
     @reconnect()
     def clear(self):
         coll = self._get_collection()
-        if not 'capped' in self._db.command("collstats", self._collection_name):
+        collstats = self._db.command("collstats", self._collection_name)
+        if not 'capped' in collstats or not collstats['capped']:
             coll.remove({})
         else:
             coll.update({}, {'$set':{'expires':timezone.now()}})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-mongodb-cash-backend',
-    version='2018.7.23',
+    version='2019.1.23',
     packages=['django_mongodb_cash_backend'],
     package_dir={'django_mongodb_cash_backend': 'django_mongodb_cash_backend'},
     provides=['django_mongodb_cash_backend'],


### PR DESCRIPTION
Syntactic subtlety in the check for "capped" value in collstats.